### PR TITLE
Adding JWTVerifier for Asymmetric KeyPair

### DIFF
--- a/src/main/java/com/acm/infra/proxy/JWTFilter.java
+++ b/src/main/java/com/acm/infra/proxy/JWTFilter.java
@@ -5,7 +5,7 @@ import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.factory.AbstractNameValueGatewayFilterFactory;
 import org.springframework.http.HttpStatus;
@@ -25,10 +25,9 @@ public class JWTFilter extends AbstractNameValueGatewayFilterFactory {
 
     private static final Logger logger = LoggerFactory.getLogger(JWTFilter.class);
 
-    @Autowired
     private final JWTVerifier jwtVerifier;
 
-    public JWTFilter(JWTVerifier jwtVerifier) {
+    public JWTFilter(@Qualifier("jwk") JWTVerifier jwtVerifier) {
         this.jwtVerifier = jwtVerifier;
     }
 


### PR DESCRIPTION
# What this PR stands for?

I've included a new _JWTVerifier_ bean for Asymmetric KeyPair tokens.

Example of _jwt.key_ properties on YAML:
```
jwt:
  key: |
    MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAhb6KBtAGC0e2K6LuqGKs
    9wd3SJCu2TErlm1xzkcQrziudmkLLVRc+2ijGVbKiM8YRm4jN7mjRLFhr9bSygRs
    jayhaiZmaDU5PMv1KnNcy3BnqY8LQE+ALamYgflz4KhKfRveS7EPKHnIe1wrzHka
    eBY3TQj9LAG6aNy5sf2l4Z0125HDCDPdwX9Vrrguo3Ynd+j9uCoeMhkjoC2FzBrz
    +N/pvELWik15TwaLvF/xC0pQMnoYHuYkYcZt6jDXQE1whrDmAC277sQmVpjWAEYP
    sjkafteeBj6bZLzxah6H7P+YDquKr+se89mRcN4XwL/CKefSoek2kt88bOvMAjwr
    wQIDAQAB
```